### PR TITLE
Simplify README title wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ~
-My dotfiles repository: modern Vim, tmux, and screen configurations with an enhanced installer.
+My dotfiles: modern Vim, tmux, and screen configurations with an enhanced installer.
 
 ## Features
 


### PR DESCRIPTION
Minor wording tweak: remove redundant 'repository' from the description.